### PR TITLE
Add HUD-compliant criminal screening review workflow

### DIFF
--- a/data/historical_applicants.json
+++ b/data/historical_applicants.json
@@ -148,7 +148,18 @@
     "debt": 30000,
     "credit_score": 612,
     "rental_history": { "evictions": 0, "late_payments": 6 },
-    "criminal_background": { "has_criminal_record": true, "type_of_crime": "misdemeanor" },
+    "criminal_background": {
+      "has_criminal_record": true,
+      "type_of_crime": "misdemeanor",
+      "records": [
+        {
+          "severity": "misdemeanor",
+          "category": "other",
+          "years_since": 1,
+          "description": "Noise violation"
+        }
+      ]
+    },
     "employment_status": "part-time",
     "proxy_group": "LegacyRedlinedZip",
     "proxy_label": "ProtectedProxy",
@@ -187,7 +198,18 @@
     "debt": 25000,
     "credit_score": 598,
     "rental_history": { "evictions": 1, "late_payments": 7 },
-    "criminal_background": { "has_criminal_record": true, "type_of_crime": "non-violent" },
+    "criminal_background": {
+      "has_criminal_record": true,
+      "type_of_crime": "non-violent",
+      "records": [
+        {
+          "severity": "felony",
+          "category": "property",
+          "years_since": 5,
+          "description": "Burglary conviction"
+        }
+      ]
+    },
     "employment_status": "unemployed",
     "proxy_group": "LegacyRedlinedZip",
     "proxy_label": "ProtectedProxy",

--- a/docs/criminalScreeningPolicy.md
+++ b/docs/criminalScreeningPolicy.md
@@ -1,0 +1,43 @@
+# Criminal Background Screening Policy
+
+## Inventory of Criminal Record Filters
+
+The background-check integration evaluates criminal history through a combination of severity, offense category, and time since conviction:
+
+- **Violent felonies** within the configurable lookback window (default: 10 years) add `recentViolentFelonyPoints` and automatically trigger an individualized review.
+- **Non-violent felonies** within the felony lookback window (default: 7 years) add `recentFelonyPoints` and require individualized review.
+- **Misdemeanors** within the misdemeanor lookback window (default: 3 years) add `recentMisdemeanorPoints` and require individualized review.
+- **Records older than the applicable lookback period** do not add recent-offense risk, but contribute `staleRecordPoints` and are documented for context.
+- **Reported histories without structured offense data** (e.g., legacy `type_of_crime` strings) are flagged for individualized review and assessed with `staleRecordPoints` until verified details are supplied.
+
+These filters are implemented in `src/lib/screening.ts` and are configurable through `src/lib/screeningConfig.ts` and the advanced calculator UI.
+
+## Alignment with 2016 HUD Criminal History Guidance
+
+HUD's April 4, 2016 guidance emphasizes (1) avoiding blanket exclusions, (2) considering the nature and severity of convictions, and (3) evaluating the time that has elapsed since the offense. The integration translates these principles into explicit lookback periods and decision aids:
+
+- **Lookback periods** are limited to 10 years for violent felonies, 7 years for other felonies, and 3 years for misdemeanors, consistent with HUD's directive to tailor policies to recency and severity rather than impose lifetime bans.
+- **Individualized review** is triggered whenever a record falls within the applicable lookback period or when insufficient detail is provided. Reviewers are prompted to consider offense circumstances, evidence of rehabilitation, and mitigating information before issuing an adverse action.
+- **Documented rationale** is captured through risk breakdowns (`breakdown.criminal`) in audit logs and API responses, ensuring reviewers can justify decisions and comply with HUD's case-by-case assessment expectations.
+
+## Case-by-Case Review Procedure
+
+1. **Collect structured record details** (severity, category, years since conviction, narrative description) via the calculator UI or API payload. Legacy string inputs still trigger review but require follow-up.
+2. **System evaluation** assigns risk points per offense and flags whether individualized review is required. Violent or recent offenses automatically produce rationale entries describing the applicable lookback and mitigation requirements.
+3. **Reviewer assessment** documents mitigating factors (rehabilitation, age at offense, nature of offense) directly in the "Summary / Context" field of the calculator. This text is stored with the audit entry for future reference.
+4. **Decision logging** persists risk scores, decisions, and the criminal-review breakdown for transparency and compliance audits.
+
+## Configuration Summary
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `thresholds.criminal.violentFelonyLookbackYears` | 10 | Maximum age for violent felony convictions considered in scoring. |
+| `thresholds.criminal.felonyLookbackYears` | 7 | Maximum age for non-violent felony convictions considered in scoring. |
+| `thresholds.criminal.misdemeanorLookbackYears` | 3 | Maximum age for misdemeanor convictions considered in scoring. |
+| `scoring.criminal.recentViolentFelonyPoints` | 4 | Risk points applied to violent felonies inside the lookback window. |
+| `scoring.criminal.recentFelonyPoints` | 3 | Risk points for other felonies inside the lookback window. |
+| `scoring.criminal.recentMisdemeanorPoints` | 2 | Risk points for misdemeanors inside the lookback window. |
+| `scoring.criminal.staleRecordPoints` | 1 | Documentation-only points for offenses outside the lookback period or lacking detail. |
+| `scoring.criminal.cleanRecordPoints` | 0 | Baseline risk when no criminal history is reported. |
+
+Reviewers should revisit these defaults periodically to confirm continued alignment with HUD policy updates and local regulations.

--- a/src/app/api/screening/route.ts
+++ b/src/app/api/screening/route.ts
@@ -3,6 +3,7 @@ import {
   tenantScreeningAlgorithm,
   type TenantData,
   type EmploymentStatus,
+  type CriminalRecord,
 } from '@/lib/screening';
 import { logAudit, getAudits } from '@/lib/audit';
 import { defaultScreeningConfig, type ScreeningConfig } from '@/lib/screeningConfig';
@@ -37,6 +38,31 @@ function validateTenantPayload(payload: any): { ok: true; data: TenantData } | {
   const type_of_crimeRaw = criminal_background?.type_of_crime;
   const type_of_crime = typeof type_of_crimeRaw === 'string' ? type_of_crimeRaw : null;
 
+  const recordsRaw = Array.isArray(criminal_background?.records) ? criminal_background.records : [];
+  const records: CriminalRecord[] = [];
+  recordsRaw.forEach((rec: any, idx) => {
+    const severity = rec?.severity;
+    const category = rec?.category;
+    const years_since = toNumber(rec?.years_since);
+
+    const validSeverity = severity === 'felony' || severity === 'misdemeanor';
+    const validCategory = ['violent', 'property', 'drug', 'other'].includes(category);
+    if (!validSeverity) errors.push(`criminal_background.records[${idx}].severity must be 'felony' or 'misdemeanor'`);
+    if (!validCategory) errors.push(`criminal_background.records[${idx}].category must be one of violent, property, drug, other`);
+    if (years_since === undefined || years_since < 0) {
+      errors.push(`criminal_background.records[${idx}].years_since must be a non-negative number`);
+    }
+
+    if (validSeverity && validCategory && years_since !== undefined && years_since >= 0) {
+      records.push({
+        severity,
+        category,
+        years_since,
+        description: typeof rec?.description === 'string' ? rec.description : null,
+      });
+    }
+  });
+
   const employment_status = payload?.employment_status as EmploymentStatus;
   const allowedEmployment: EmploymentStatus[] = ['full-time', 'part-time', 'unemployed'];
   if (!allowedEmployment.includes(employment_status)) {
@@ -53,7 +79,11 @@ function validateTenantPayload(payload: any): { ok: true; data: TenantData } | {
       debt: debt!,
       credit_score: credit_score!,
       rental_history: { evictions: evictions!, late_payments: late_payments! },
-      criminal_background: { has_criminal_record, type_of_crime },
+      criminal_background: {
+        has_criminal_record,
+        type_of_crime,
+        records: records.length ? records : undefined,
+      },
       employment_status,
     },
   };
@@ -71,7 +101,7 @@ export async function POST(request: NextRequest) {
       return Response.json({ errors: config.errors }, { status: 400 });
     }
 
-    const { risk_score, decision } = tenantScreeningAlgorithm(validation.data, config.value);
+    const { risk_score, decision, breakdown } = tenantScreeningAlgorithm(validation.data, config.value);
 
     // Audit the evaluation in-memory
     logAudit({
@@ -80,9 +110,10 @@ export async function POST(request: NextRequest) {
       input: validation.data,
       risk_score,
       decision,
+      breakdown,
     });
 
-    return Response.json({ risk_score, decision });
+    return Response.json({ risk_score, decision, breakdown });
   } catch (e) {
     return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
   }
@@ -107,6 +138,11 @@ type PartialConfig = Partial<{
       dtiException: number;
     }>;
     credit: Partial<{ excellentMin: number; goodMin: number }>;
+    criminal: Partial<{
+      violentFelonyLookbackYears: number;
+      felonyLookbackYears: number;
+      misdemeanorLookbackYears: number;
+    }>;
   }>;
   scoring: Partial<{
     dtiHigh: number;
@@ -118,7 +154,13 @@ type PartialConfig = Partial<{
     }>;
     credit: Partial<{ excellent: number; good: number; poor: number }>;
     rental: Partial<{ evictionPoints: number; latePaymentsThreshold: number; latePaymentsPoints: number }>;
-    criminal: Partial<{ hasRecordPoints: number }>;
+    criminal: Partial<{
+      cleanRecordPoints: number;
+      staleRecordPoints: number;
+      recentMisdemeanorPoints: number;
+      recentFelonyPoints: number;
+      recentViolentFelonyPoints: number;
+    }>;
     employment: Partial<{ fullTime: number; partTime: number; unemployed: number }>;
   }>;
   decision: Partial<{ approvedMax: number; flaggedMax: number }>;
@@ -148,6 +190,18 @@ function validateAndMergeConfig(override: any): { value: ScreeningConfig; errors
       if (isFiniteNumber(c.excellentMin)) out.thresholds.credit.excellentMin = c.excellentMin!;
       if (isFiniteNumber(c.goodMin)) out.thresholds.credit.goodMin = c.goodMin!;
     }
+    if (cfg.thresholds.criminal) {
+      const cr = cfg.thresholds.criminal;
+      if (isFiniteNumber(cr.violentFelonyLookbackYears)) {
+        out.thresholds.criminal.violentFelonyLookbackYears = cr.violentFelonyLookbackYears!;
+      }
+      if (isFiniteNumber(cr.felonyLookbackYears)) {
+        out.thresholds.criminal.felonyLookbackYears = cr.felonyLookbackYears!;
+      }
+      if (isFiniteNumber(cr.misdemeanorLookbackYears)) {
+        out.thresholds.criminal.misdemeanorLookbackYears = cr.misdemeanorLookbackYears!;
+      }
+    }
   }
 
   // scoring
@@ -174,7 +228,17 @@ function validateAndMergeConfig(override: any): { value: ScreeningConfig; errors
     }
     if (cfg.scoring.criminal) {
       const cr = cfg.scoring.criminal;
-      if (isFiniteNumber(cr.hasRecordPoints)) out.scoring.criminal.hasRecordPoints = cr.hasRecordPoints!;
+      if (isFiniteNumber(cr.cleanRecordPoints)) out.scoring.criminal.cleanRecordPoints = cr.cleanRecordPoints!;
+      if (isFiniteNumber(cr.staleRecordPoints)) out.scoring.criminal.staleRecordPoints = cr.staleRecordPoints!;
+      if (isFiniteNumber(cr.recentMisdemeanorPoints)) {
+        out.scoring.criminal.recentMisdemeanorPoints = cr.recentMisdemeanorPoints!;
+      }
+      if (isFiniteNumber(cr.recentFelonyPoints)) {
+        out.scoring.criminal.recentFelonyPoints = cr.recentFelonyPoints!;
+      }
+      if (isFiniteNumber(cr.recentViolentFelonyPoints)) {
+        out.scoring.criminal.recentViolentFelonyPoints = cr.recentViolentFelonyPoints!;
+      }
     }
     if (cfg.scoring.employment) {
       const e = cfg.scoring.employment;

--- a/src/app/screening/calculator/page.tsx
+++ b/src/app/screening/calculator/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import Button from '@/components/Button';
 import { defaultScreeningConfig } from '@/lib/screeningConfig';
+import type { RiskBreakdown } from '@/lib/screening';
 
 function NumberField({ label, value, onChange }: { label: string; value: string; onChange: (val: string) => void }) {
   return (
@@ -21,13 +22,20 @@ function NumberField({ label, value, onChange }: { label: string; value: string;
 
 type EmploymentStatus = 'full-time' | 'part-time' | 'unemployed';
 
+interface CriminalRecordForm {
+  severity: 'felony' | 'misdemeanor';
+  category: 'violent' | 'property' | 'drug' | 'other';
+  years_since: string;
+  description: string;
+}
+
 interface FormState {
   income: string;
   monthly_rent: string;
   debt: string;
   credit_score: string;
   rental_history: { evictions: string; late_payments: string };
-  criminal_background: { has_criminal_record: boolean; type_of_crime: string };
+  criminal_background: { has_criminal_record: boolean; summary: string; records: CriminalRecordForm[] };
   employment_status: EmploymentStatus;
 }
 
@@ -38,10 +46,10 @@ export default function ScreeningCalculatorPage() {
     debt: '15000',
     credit_score: '720',
     rental_history: { evictions: '0', late_payments: '2' },
-    criminal_background: { has_criminal_record: false, type_of_crime: '' },
+    criminal_background: { has_criminal_record: false, summary: '', records: [] },
     employment_status: 'full-time',
   });
-  const [result, setResult] = useState<{ risk_score: number; decision: string } | null>(null);
+  const [result, setResult] = useState<{ risk_score: number; decision: string; breakdown?: RiskBreakdown } | null>(null);
   const [errors, setErrors] = useState<string[] | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [audits, setAudits] = useState<any[] | null>(null);
@@ -69,10 +77,24 @@ export default function ScreeningCalculatorPage() {
       },
       criminal_background: {
         has_criminal_record: form.criminal_background.has_criminal_record,
-        type_of_crime: form.criminal_background.has_criminal_record ? form.criminal_background.type_of_crime : null,
+        type_of_crime:
+          form.criminal_background.has_criminal_record && form.criminal_background.summary
+            ? form.criminal_background.summary
+            : null,
       },
       employment_status: form.employment_status,
     };
+
+    if (form.criminal_background.has_criminal_record) {
+      payload.criminal_background.records = form.criminal_background.records
+        .map((rec) => ({
+          severity: rec.severity,
+          category: rec.category,
+          years_since: Number(rec.years_since),
+          description: rec.description.trim() ? rec.description.trim() : undefined,
+        }))
+        .filter((rec) => Number.isFinite(rec.years_since) && rec.years_since >= 0);
+    }
 
     if (customEnabled) {
       payload.config = fromConfigForm(configForm);
@@ -129,6 +151,11 @@ export default function ScreeningCalculatorPage() {
           excellentMin: String(cfg.thresholds.credit.excellentMin),
           goodMin: String(cfg.thresholds.credit.goodMin),
         },
+        criminal: {
+          violentFelonyLookbackYears: String(cfg.thresholds.criminal.violentFelonyLookbackYears),
+          felonyLookbackYears: String(cfg.thresholds.criminal.felonyLookbackYears),
+          misdemeanorLookbackYears: String(cfg.thresholds.criminal.misdemeanorLookbackYears),
+        },
       },
       scoring: {
         dtiHigh: String(cfg.scoring.dtiHigh),
@@ -148,7 +175,13 @@ export default function ScreeningCalculatorPage() {
           latePaymentsThreshold: String(cfg.scoring.rental.latePaymentsThreshold),
           latePaymentsPoints: String(cfg.scoring.rental.latePaymentsPoints),
         },
-        criminal: { hasRecordPoints: String(cfg.scoring.criminal.hasRecordPoints) },
+        criminal: {
+          cleanRecordPoints: String(cfg.scoring.criminal.cleanRecordPoints),
+          staleRecordPoints: String(cfg.scoring.criminal.staleRecordPoints),
+          recentMisdemeanorPoints: String(cfg.scoring.criminal.recentMisdemeanorPoints),
+          recentFelonyPoints: String(cfg.scoring.criminal.recentFelonyPoints),
+          recentViolentFelonyPoints: String(cfg.scoring.criminal.recentViolentFelonyPoints),
+        },
         employment: {
           fullTime: String(cfg.scoring.employment.fullTime),
           partTime: String(cfg.scoring.employment.partTime),
@@ -176,6 +209,11 @@ export default function ScreeningCalculatorPage() {
           excellentMin: Number(cf.thresholds.credit.excellentMin),
           goodMin: Number(cf.thresholds.credit.goodMin),
         },
+        criminal: {
+          violentFelonyLookbackYears: Number(cf.thresholds.criminal.violentFelonyLookbackYears),
+          felonyLookbackYears: Number(cf.thresholds.criminal.felonyLookbackYears),
+          misdemeanorLookbackYears: Number(cf.thresholds.criminal.misdemeanorLookbackYears),
+        },
       },
       scoring: {
         dtiHigh: Number(cf.scoring.dtiHigh),
@@ -195,7 +233,13 @@ export default function ScreeningCalculatorPage() {
           latePaymentsThreshold: Number(cf.scoring.rental.latePaymentsThreshold),
           latePaymentsPoints: Number(cf.scoring.rental.latePaymentsPoints),
         },
-        criminal: { hasRecordPoints: Number(cf.scoring.criminal.hasRecordPoints) },
+        criminal: {
+          cleanRecordPoints: Number(cf.scoring.criminal.cleanRecordPoints),
+          staleRecordPoints: Number(cf.scoring.criminal.staleRecordPoints),
+          recentMisdemeanorPoints: Number(cf.scoring.criminal.recentMisdemeanorPoints),
+          recentFelonyPoints: Number(cf.scoring.criminal.recentFelonyPoints),
+          recentViolentFelonyPoints: Number(cf.scoring.criminal.recentViolentFelonyPoints),
+        },
         employment: {
           fullTime: Number(cf.scoring.employment.fullTime),
           partTime: Number(cf.scoring.employment.partTime),
@@ -212,7 +256,20 @@ export default function ScreeningCalculatorPage() {
   function exportCsv() {
     if (!audits || audits.length === 0) return;
     const headers = [
-      'timestamp','income','monthly_rent','debt','credit_score','evictions','late_payments','has_criminal_record','type_of_crime','employment_status','risk_score','decision'
+      'timestamp',
+      'income',
+      'monthly_rent',
+      'debt',
+      'credit_score',
+      'evictions',
+      'late_payments',
+      'has_criminal_record',
+      'criminal_summary',
+      'criminal_records',
+      'requires_individual_review',
+      'employment_status',
+      'risk_score',
+      'decision',
     ];
     const rows = audits.map((a) => [
       a.timestamp,
@@ -224,6 +281,13 @@ export default function ScreeningCalculatorPage() {
       a.input.rental_history?.late_payments ?? '',
       a.input.criminal_background?.has_criminal_record ?? '',
       a.input.criminal_background?.type_of_crime ?? '',
+      (a.input.criminal_background?.records ?? [])
+        .map(
+          (rec: any) =>
+            `${rec.severity}:${rec.category}:${rec.years_since}${rec.description ? ` (${rec.description})` : ''}`,
+        )
+        .join('; '),
+      a.breakdown?.criminal?.requiresIndividualReview ?? '',
       a.input.employment_status ?? '',
       a.risk_score,
       a.decision,
@@ -286,6 +350,13 @@ export default function ScreeningCalculatorPage() {
         if (isNum(c.excellentMin)) out.thresholds.credit.excellentMin = c.excellentMin;
         if (isNum(c.goodMin)) out.thresholds.credit.goodMin = c.goodMin;
       }
+      if (override.thresholds.criminal) {
+        const cr = override.thresholds.criminal;
+        if (isNum(cr.violentFelonyLookbackYears))
+          out.thresholds.criminal.violentFelonyLookbackYears = cr.violentFelonyLookbackYears;
+        if (isNum(cr.felonyLookbackYears)) out.thresholds.criminal.felonyLookbackYears = cr.felonyLookbackYears;
+        if (isNum(cr.misdemeanorLookbackYears)) out.thresholds.criminal.misdemeanorLookbackYears = cr.misdemeanorLookbackYears;
+      }
     }
     if (override.scoring) {
       if (isNum(override.scoring.dtiHigh)) out.scoring.dtiHigh = override.scoring.dtiHigh;
@@ -310,7 +381,13 @@ export default function ScreeningCalculatorPage() {
       }
       if (override.scoring.criminal) {
         const cr = override.scoring.criminal;
-        if (isNum(cr.hasRecordPoints)) out.scoring.criminal.hasRecordPoints = cr.hasRecordPoints;
+        if (isNum(cr.cleanRecordPoints)) out.scoring.criminal.cleanRecordPoints = cr.cleanRecordPoints;
+        if (isNum(cr.staleRecordPoints)) out.scoring.criminal.staleRecordPoints = cr.staleRecordPoints;
+        if (isNum(cr.recentMisdemeanorPoints))
+          out.scoring.criminal.recentMisdemeanorPoints = cr.recentMisdemeanorPoints;
+        if (isNum(cr.recentFelonyPoints)) out.scoring.criminal.recentFelonyPoints = cr.recentFelonyPoints;
+        if (isNum(cr.recentViolentFelonyPoints))
+          out.scoring.criminal.recentViolentFelonyPoints = cr.recentViolentFelonyPoints;
       }
       if (override.scoring.employment) {
         const e = override.scoring.employment;
@@ -434,23 +511,151 @@ export default function ScreeningCalculatorPage() {
           <section>
             <h2 className="text-xl font-semibold text-gray-800 mb-4">Background & Employment</h2>
             <div className="grid md:grid-cols-2 gap-4">
-              <div>
+              <div className="space-y-3">
                 <label className="flex items-center gap-2 text-sm font-medium text-gray-700">
                   <input
                     type="checkbox"
                     checked={form.criminal_background.has_criminal_record}
-                    onChange={(e) => setForm({ ...form, criminal_background: { ...form.criminal_background, has_criminal_record: e.target.checked } })}
+                    onChange={(e) => {
+                      const checked = e.target.checked;
+                      setForm({
+                        ...form,
+                        criminal_background: {
+                          ...form.criminal_background,
+                          has_criminal_record: checked,
+                          records: checked ? form.criminal_background.records.length ? form.criminal_background.records : [{ severity: 'felony', category: 'property', years_since: '0', description: '' }] : [],
+                        },
+                      });
+                    }}
                   />
                   Has Criminal Record
                 </label>
-                <input
-                  type="text"
-                  placeholder="Type of crime (optional)"
-                  value={form.criminal_background.type_of_crime}
-                  onChange={(e) => setForm({ ...form, criminal_background: { ...form.criminal_background, type_of_crime: e.target.value } })}
-                  className="mt-2 w-full border rounded px-3 py-2"
-                  disabled={!form.criminal_background.has_criminal_record}
-                />
+
+                {form.criminal_background.has_criminal_record && (
+                  <div className="space-y-3">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Summary / Context</label>
+                      <textarea
+                        className="w-full border rounded px-3 py-2"
+                        placeholder="Briefly describe the circumstances or rehabilitation steps"
+                        value={form.criminal_background.summary}
+                        onChange={(e) =>
+                          setForm({
+                            ...form,
+                            criminal_background: { ...form.criminal_background, summary: e.target.value },
+                          })
+                        }
+                        rows={3}
+                      />
+                    </div>
+
+                    <div className="space-y-4">
+                      {form.criminal_background.records.map((record, idx) => (
+                        <div key={idx} className="border rounded-lg p-3 space-y-3 bg-gray-50">
+                          <div className="flex justify-between items-center">
+                            <h3 className="text-sm font-semibold text-gray-700">Offense {idx + 1}</h3>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                const next = form.criminal_background.records.filter((_, i) => i !== idx);
+                                setForm({
+                                  ...form,
+                                  criminal_background: {
+                                    ...form.criminal_background,
+                                    records: next.length ? next : [{ severity: 'felony', category: 'property', years_since: '0', description: '' }],
+                                  },
+                                });
+                              }}
+                              className="text-xs text-red-600 hover:underline"
+                            >
+                              Remove
+                            </button>
+                          </div>
+                          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                            <div>
+                              <label className="block text-xs font-medium text-gray-600 mb-1">Severity</label>
+                              <select
+                                className="w-full border rounded px-3 py-2"
+                                value={record.severity}
+                                onChange={(e) => {
+                                  const next = [...form.criminal_background.records];
+                                  next[idx] = { ...next[idx], severity: e.target.value as 'felony' | 'misdemeanor' };
+                                  setForm({ ...form, criminal_background: { ...form.criminal_background, records: next } });
+                                }}
+                              >
+                                <option value="felony">Felony</option>
+                                <option value="misdemeanor">Misdemeanor</option>
+                              </select>
+                            </div>
+                            <div>
+                              <label className="block text-xs font-medium text-gray-600 mb-1">Category</label>
+                              <select
+                                className="w-full border rounded px-3 py-2"
+                                value={record.category}
+                                onChange={(e) => {
+                                  const next = [...form.criminal_background.records];
+                                  next[idx] = { ...next[idx], category: e.target.value as CriminalRecordForm['category'] };
+                                  setForm({ ...form, criminal_background: { ...form.criminal_background, records: next } });
+                                }}
+                              >
+                                <option value="violent">Violent</option>
+                                <option value="property">Property</option>
+                                <option value="drug">Drug</option>
+                                <option value="other">Other</option>
+                              </select>
+                            </div>
+                            <div>
+                              <label className="block text-xs font-medium text-gray-600 mb-1">Years Since Conviction</label>
+                              <input
+                                type="number"
+                                min={0}
+                                className="w-full border rounded px-3 py-2"
+                                value={record.years_since}
+                                onChange={(e) => {
+                                  const next = [...form.criminal_background.records];
+                                  next[idx] = { ...next[idx], years_since: e.target.value };
+                                  setForm({ ...form, criminal_background: { ...form.criminal_background, records: next } });
+                                }}
+                              />
+                            </div>
+                            <div>
+                              <label className="block text-xs font-medium text-gray-600 mb-1">Offense Description</label>
+                              <input
+                                type="text"
+                                className="w-full border rounded px-3 py-2"
+                                value={record.description}
+                                onChange={(e) => {
+                                  const next = [...form.criminal_background.records];
+                                  next[idx] = { ...next[idx], description: e.target.value };
+                                  setForm({ ...form, criminal_background: { ...form.criminal_background, records: next } });
+                                }}
+                                placeholder="e.g., Burglary, rehabilitation completed"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() =>
+                          setForm({
+                            ...form,
+                            criminal_background: {
+                              ...form.criminal_background,
+                              records: [
+                                ...form.criminal_background.records,
+                                { severity: 'felony', category: 'property', years_since: '0', description: '' },
+                              ],
+                            },
+                          })
+                        }
+                      >
+                        Add Another Offense
+                      </Button>
+                    </div>
+                  </div>
+                )}
               </div>
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">Employment Status</label>
@@ -481,6 +686,28 @@ export default function ScreeningCalculatorPage() {
             <div className="rounded border border-green-300 bg-green-50 text-green-800 p-4">
               <p className="font-medium">Risk Score: {result.risk_score}</p>
               <p className="font-medium">Decision: {result.decision}</p>
+              {result.breakdown?.criminal && (
+                <div className="mt-2 text-sm text-green-900 space-y-2">
+                  <p>
+                    Criminal history requires individualized review:{' '}
+                    <span className="font-semibold">
+                      {result.breakdown.criminal.requiresIndividualReview ? 'Yes' : 'No'}
+                    </span>
+                  </p>
+                  {result.breakdown.criminal.rationale.length > 0 && (
+                    <ul className="list-disc list-inside space-y-1">
+                      {result.breakdown.criminal.rationale.map((item, idx) => (
+                        <li key={idx}>{item}</li>
+                      ))}
+                    </ul>
+                  )}
+                  {result.breakdown.criminal.disregardedRecords.length > 0 && (
+                    <p className="text-xs text-green-700">
+                      Older records documented but not scored: {result.breakdown.criminal.disregardedRecords.length}
+                    </p>
+                  )}
+                </div>
+              )}
             </div>
           )}
 
@@ -498,7 +725,7 @@ export default function ScreeningCalculatorPage() {
                   debt: '15000',
                   credit_score: '720',
                   rental_history: { evictions: '0', late_payments: '2' },
-                  criminal_background: { has_criminal_record: false, type_of_crime: '' },
+                  criminal_background: { has_criminal_record: false, summary: '', records: [] },
                   employment_status: 'full-time',
                 });
                 setErrors(null);
@@ -558,6 +785,21 @@ export default function ScreeningCalculatorPage() {
                       />
                       <NumberField label="Credit Excellent Min" value={configForm.thresholds.credit.excellentMin} onChange={(v)=>setConfigForm({...configForm, thresholds: {...configForm.thresholds, credit: {...configForm.thresholds.credit, excellentMin: v}}})} />
                       <NumberField label="Credit Good Min" value={configForm.thresholds.credit.goodMin} onChange={(v)=>setConfigForm({...configForm, thresholds: {...configForm.thresholds, credit: {...configForm.thresholds.credit, goodMin: v}}})} />
+                      <NumberField
+                        label="Violent Felony Lookback (yrs)"
+                        value={configForm.thresholds.criminal.violentFelonyLookbackYears}
+                        onChange={(v)=>setConfigForm({...configForm, thresholds: {...configForm.thresholds, criminal: {...configForm.thresholds.criminal, violentFelonyLookbackYears: v}}})}
+                      />
+                      <NumberField
+                        label="Felony Lookback (yrs)"
+                        value={configForm.thresholds.criminal.felonyLookbackYears}
+                        onChange={(v)=>setConfigForm({...configForm, thresholds: {...configForm.thresholds, criminal: {...configForm.thresholds.criminal, felonyLookbackYears: v}}})}
+                      />
+                      <NumberField
+                        label="Misdemeanor Lookback (yrs)"
+                        value={configForm.thresholds.criminal.misdemeanorLookbackYears}
+                        onChange={(v)=>setConfigForm({...configForm, thresholds: {...configForm.thresholds, criminal: {...configForm.thresholds.criminal, misdemeanorLookbackYears: v}}})}
+                      />
                     </div>
                   </section>
                   <section>
@@ -590,7 +832,11 @@ export default function ScreeningCalculatorPage() {
                       <NumberField label="Eviction Points" value={configForm.scoring.rental.evictionPoints} onChange={(v)=>setConfigForm({...configForm, scoring: {...configForm.scoring, rental: {...configForm.scoring.rental, evictionPoints: v}}})} />
                       <NumberField label="Late Pmts Threshold" value={configForm.scoring.rental.latePaymentsThreshold} onChange={(v)=>setConfigForm({...configForm, scoring: {...configForm.scoring, rental: {...configForm.scoring.rental, latePaymentsThreshold: v}}})} />
                       <NumberField label="Late Pmts Points" value={configForm.scoring.rental.latePaymentsPoints} onChange={(v)=>setConfigForm({...configForm, scoring: {...configForm.scoring, rental: {...configForm.scoring.rental, latePaymentsPoints: v}}})} />
-                      <NumberField label="Criminal Record Points" value={configForm.scoring.criminal.hasRecordPoints} onChange={(v)=>setConfigForm({...configForm, scoring: {...configForm.scoring, criminal: {...configForm.scoring.criminal, hasRecordPoints: v}}})} />
+                      <NumberField label="Clean Record Points" value={configForm.scoring.criminal.cleanRecordPoints} onChange={(v)=>setConfigForm({...configForm, scoring: {...configForm.scoring, criminal: {...configForm.scoring.criminal, cleanRecordPoints: v}}})} />
+                      <NumberField label="Stale Record Points" value={configForm.scoring.criminal.staleRecordPoints} onChange={(v)=>setConfigForm({...configForm, scoring: {...configForm.scoring, criminal: {...configForm.scoring.criminal, staleRecordPoints: v}}})} />
+                      <NumberField label="Recent Misdemeanor Points" value={configForm.scoring.criminal.recentMisdemeanorPoints} onChange={(v)=>setConfigForm({...configForm, scoring: {...configForm.scoring, criminal: {...configForm.scoring.criminal, recentMisdemeanorPoints: v}}})} />
+                      <NumberField label="Recent Felony Points" value={configForm.scoring.criminal.recentFelonyPoints} onChange={(v)=>setConfigForm({...configForm, scoring: {...configForm.scoring, criminal: {...configForm.scoring.criminal, recentFelonyPoints: v}}})} />
+                      <NumberField label="Violent Felony Points" value={configForm.scoring.criminal.recentViolentFelonyPoints} onChange={(v)=>setConfigForm({...configForm, scoring: {...configForm.scoring, criminal: {...configForm.scoring.criminal, recentViolentFelonyPoints: v}}})} />
                       <NumberField label="Employment Full-time" value={configForm.scoring.employment.fullTime} onChange={(v)=>setConfigForm({...configForm, scoring: {...configForm.scoring, employment: {...configForm.scoring.employment, fullTime: v}}})} />
                       <NumberField label="Employment Part-time" value={configForm.scoring.employment.partTime} onChange={(v)=>setConfigForm({...configForm, scoring: {...configForm.scoring, employment: {...configForm.scoring.employment, partTime: v}}})} />
                       <NumberField label="Employment Unemployed" value={configForm.scoring.employment.unemployed} onChange={(v)=>setConfigForm({...configForm, scoring: {...configForm.scoring, employment: {...configForm.scoring.employment, unemployed: v}}})} />
@@ -643,6 +889,8 @@ export default function ScreeningCalculatorPage() {
                     <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Credit</th>
                     <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Score</th>
                     <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Decision</th>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Review</th>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Criminal Notes</th>
                   </tr>
                 </thead>
                 <tbody className="bg-white divide-y divide-gray-200">
@@ -668,6 +916,12 @@ export default function ScreeningCalculatorPage() {
                         >
                           {a.decision}
                         </span>
+                      </td>
+                      <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-900">
+                        {a.breakdown?.criminal?.requiresIndividualReview ? 'Yes' : 'No'}
+                      </td>
+                      <td className="px-4 py-2 text-sm text-gray-600 max-w-xs">
+                        {a.breakdown?.criminal?.rationale?.[0] ?? ''}
                       </td>
                     </tr>
                   ))}

--- a/src/app/screening/page.tsx
+++ b/src/app/screening/page.tsx
@@ -93,7 +93,7 @@ export default function ScreeningPage() {
                   ⚠ Minor traffic violation 3 years ago
                 </p>
                 <p className="text-sm text-yellow-700">
-                  ✓ No felony convictions
+                  ✓ Individualized review for any criminal records following HUD guidance
                 </p>
               </div>
               

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,4 +1,4 @@
-import type { TenantData, Decision } from './screening';
+import type { TenantData, Decision, RiskBreakdown } from './screening';
 
 export interface AuditEntry {
   id: string;
@@ -6,6 +6,7 @@ export interface AuditEntry {
   input: TenantData;
   risk_score: number;
   decision: Decision;
+  breakdown: RiskBreakdown;
 }
 
 const MAX = 50;

--- a/src/lib/screeningConfig.ts
+++ b/src/lib/screeningConfig.ts
@@ -11,6 +11,11 @@ export interface ScreeningConfig {
       excellentMin: number; // inclusive
       goodMin: number; // inclusive
     };
+    criminal: {
+      violentFelonyLookbackYears: number;
+      felonyLookbackYears: number;
+      misdemeanorLookbackYears: number;
+    };
   };
   scoring: {
     dtiHigh: number; // points when DTI exceeds thresholds.dtiHigh
@@ -26,7 +31,13 @@ export interface ScreeningConfig {
       latePaymentsThreshold: number;
       latePaymentsPoints: number;
     };
-    criminal: { hasRecordPoints: number };
+    criminal: {
+      cleanRecordPoints: number;
+      staleRecordPoints: number;
+      recentMisdemeanorPoints: number;
+      recentFelonyPoints: number;
+      recentViolentFelonyPoints: number;
+    };
     employment: { fullTime: number; partTime: number; unemployed: number };
   };
   decision: {
@@ -45,13 +56,24 @@ export const defaultScreeningConfig: ScreeningConfig = {
       dtiException: 0.3,
     },
     credit: { excellentMin: 750, goodMin: 650 },
+    criminal: {
+      violentFelonyLookbackYears: 10,
+      felonyLookbackYears: 7,
+      misdemeanorLookbackYears: 3,
+    },
   },
   scoring: {
     dtiHigh: 2,
     affordability: { meetsRule: 0, partialCredit: 1, dtiException: 2, fail: 4 },
     credit: { excellent: 0, good: 1, poor: 2 },
     rental: { evictionPoints: 3, latePaymentsThreshold: 3, latePaymentsPoints: 2 },
-    criminal: { hasRecordPoints: 3 },
+    criminal: {
+      cleanRecordPoints: 0,
+      staleRecordPoints: 1,
+      recentMisdemeanorPoints: 2,
+      recentFelonyPoints: 3,
+      recentViolentFelonyPoints: 4,
+    },
     employment: { fullTime: 0, partTime: 1, unemployed: 2 },
   },
   decision: {


### PR DESCRIPTION
## Summary
- add configurable HUD-aligned lookback periods and detailed criminal risk evaluation with individualized review logging
- extend the screening API and calculator UI to capture structured offenses, surface review rationales, and expose audit breakdowns
- document the new felony/misdemeanor handling and case-by-case policy in a dedicated criminal screening guide

## Testing
- npm run lint *(fails: package.json contains invalid JSON before this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d6996f656c832aa66a1a6a39c9a85b